### PR TITLE
certctl: strip trailing slashes from DESTDIR

### DIFF
--- a/usr.sbin/certctl/certctl.sh
+++ b/usr.sbin/certctl/certctl.sh
@@ -276,6 +276,8 @@ while getopts D:M:nUv flag; do
 done
 shift $(( $OPTIND - 1 ))
 
+DESTDIR=${DESTDIR%/}
+
 : ${METALOG:=${DESTDIR}/METALOG}
 INSTALLFLAGS=
 [ $UNPRIV -eq 1 ] && INSTALLFLAGS="-U -M ${METALOG} -D ${DESTDIR}"


### PR DESCRIPTION
Solves duplicate slashes in paths

e.g.
```
Scanning //usr/share/certs/trusted for certificates...
Scanning //usr/local/share/certs for certificates...
```