### PR TITLE
linuxulator: add sendfile fallback for non-socket FDs

### DIFF
--- a/sys/compat/linux/linux_socket.c
+++ b/sys/compat/linux/linux_socket.c
@@ -54,6 +54,8 @@ __FBSDID("$FreeBSD$");
 #include <sys/syslog.h>
 #include <sys/un.h>
 #include <sys/unistd.h>
+#include <sys/protosw.h>
+#include <sys/vnode.h>
 
 #include <security/audit/audit.h>
 
@@ -76,7 +78,6 @@ __FBSDID("$FreeBSD$");
 #include <machine/../linux/linux_proto.h>
 #endif
 #include <compat/linux/linux_common.h>
-#include <compat/linux/linux_emul.h>
 #include <compat/linux/linux_file.h>
 #include <compat/linux/linux_mib.h>
 #include <compat/linux/linux_socket.h>
@@ -180,8 +181,6 @@ linux_to_bsd_ip_sockopt(int opt)
 	case LINUX_MCAST_LEAVE_SOURCE_GROUP:
 		LINUX_RATELIMIT_MSG_NOTTESTED("IPv4 socket option IP_MCAST_LEAVE_SOURCE_GROUP");
 		return (MCAST_LEAVE_SOURCE_GROUP);
-	case LINUX_IP_RECVORIGDSTADDR:
-		return (IP_RECVORIGDSTADDR);
 
 	/* known but not implemented sockopts */
 	case LINUX_IP_ROUTER_ALERT:
@@ -550,18 +549,12 @@ linux_to_bsd_so_sockopt(int opt)
 		return (SO_RCVTIMEO);
 	case LINUX_SO_SNDTIMEO:
 		return (SO_SNDTIMEO);
-	case LINUX_SO_TIMESTAMPO:
-	case LINUX_SO_TIMESTAMPN:
+	case LINUX_SO_TIMESTAMP:
 		return (SO_TIMESTAMP);
-	case LINUX_SO_TIMESTAMPNSO:
-	case LINUX_SO_TIMESTAMPNSN:
-		return (SO_BINTIME);
 	case LINUX_SO_ACCEPTCONN:
 		return (SO_ACCEPTCONN);
 	case LINUX_SO_PROTOCOL:
 		return (SO_PROTOCOL);
-	case LINUX_SO_DOMAIN:
-		return (SO_DOMAIN);
 	}
 	return (-1);
 }
@@ -651,27 +644,8 @@ linux_to_bsd_cmsg_type(int cmsg_type)
 }
 
 static int
-bsd_to_linux_ip_cmsg_type(int cmsg_type)
+bsd_to_linux_cmsg_type(int cmsg_type)
 {
-
-	switch (cmsg_type) {
-	case IP_RECVORIGDSTADDR:
-		return (LINUX_IP_RECVORIGDSTADDR);
-	}
-	return (-1);
-}
-
-static int
-bsd_to_linux_cmsg_type(struct proc *p, int cmsg_type, int cmsg_level)
-{
-	struct linux_pemuldata *pem;
-
-	if (cmsg_level == IPPROTO_IP)
-		return (bsd_to_linux_ip_cmsg_type(cmsg_type));
-	if (cmsg_level != SOL_SOCKET)
-		return (-1);
-
-	pem = pem_find(p);
 
 	switch (cmsg_type) {
 	case SCM_RIGHTS:
@@ -681,9 +655,7 @@ bsd_to_linux_cmsg_type(struct proc *p, int cmsg_type, int cmsg_level)
 	case SCM_CREDS2:
 		return (LINUX_SCM_CREDENTIALS);
 	case SCM_TIMESTAMP:
-		return (pem->so_timestamp);
-	case SCM_BINTIME:
-		return (pem->so_timestampns);
+		return (LINUX_SCM_TIMESTAMP);
 	}
 	return (-1);
 }
@@ -757,9 +729,9 @@ linux_copyout_sockaddr(const struct sockaddr *sa, void *uaddr, size_t len)
 	error = bsd_to_linux_sockaddr(sa, &lsa, len);
 	if (error != 0)
 		return (error);
-
+	
 	error = copyout(lsa, uaddr, len);
-	free(lsa, M_LINUX);
+	free(lsa, M_SONAME);
 
 	return (error);
 }
@@ -1074,9 +1046,11 @@ linux_accept_common(struct thread *td, int s, l_uintptr_t addr,
 
 	if (len != 0) {
 		error = linux_copyout_sockaddr(sa, PTRIN(addr), len);
-		if (error == 0)
-			error = copyout(&len, PTRIN(namelen),
-			    sizeof(len));
+
+		/*
+		 * XXX: We should also copyout the len, shouldn't we?
+		 */
+
 		if (error != 0) {
 			fdclose(td, fp, td->td_retval[0]);
 			td->td_retval[0] = 0;
@@ -1266,29 +1240,19 @@ linux_sendto(struct thread *td, struct linux_sendto_args *args)
 {
 	struct msghdr msg;
 	struct iovec aiov;
-	struct socket *so;
-	struct file *fp;
-	int error;
 
 	if (linux_check_hdrincl(td, args->s) == 0)
 		/* IP_HDRINCL set, tweak the packet before sending */
 		return (linux_sendto_hdrincl(td, args));
 
-	bzero(&msg, sizeof(msg));
-	error = getsock_cap(td, args->s, &cap_send_connect_rights,
-	    &fp, NULL, NULL);
-	if (error != 0)
-		return (error);
-	so = fp->f_data;
-	if ((so->so_state & (SS_ISCONNECTED|SS_ISCONNECTING)) == 0) {
-		msg.msg_name = PTRIN(args->to);
-		msg.msg_namelen = args->tolen;
-	}
+	msg.msg_name = PTRIN(args->to);
+	msg.msg_namelen = args->tolen;
 	msg.msg_iov = &aiov;
 	msg.msg_iovlen = 1;
+	msg.msg_control = NULL;
+	msg.msg_flags = 0;
 	aiov.iov_base = PTRIN(args->msg);
 	aiov.iov_len = args->len;
-	fdrop(fp, td);
 	return (linux_sendit(td, args->s, &msg, args->flags, NULL,
 	    UIO_USERSPACE));
 }
@@ -1308,7 +1272,6 @@ linux_recvfrom(struct thread *td, struct linux_recvfrom_args *args)
 			return (error);
 		if (fromlen < 0)
 			return (EINVAL);
-		fromlen = min(fromlen, SOCK_MAXADDRLEN);
 		sa = malloc(fromlen, M_SONAME, M_WAITOK);
 	} else {
 		fromlen = 0;
@@ -1328,16 +1291,8 @@ linux_recvfrom(struct thread *td, struct linux_recvfrom_args *args)
 	if (error != 0)
 		goto out;
 
-	/*
-	 * XXX. Seems that FreeBSD is different from Linux here. Linux
-	 * fill source address if underlying protocol provides it, while
-	 * FreeBSD fill it if underlying protocol is not connection-oriented.
-	 * So, kern_recvit() set msg.msg_namelen to 0 if protocol pr_flags
-	 * does not contains PR_ADDR flag.
-	 */
-	if (PTRIN(args->from) != NULL && msg.msg_namelen != 0)
-		error = linux_copyout_sockaddr(sa, PTRIN(args->from),
-		    msg.msg_namelen);
+	if (PTRIN(args->from) != NULL)
+		error = linux_copyout_sockaddr(sa, PTRIN(args->from), msg.msg_namelen);
 
 	if (error == 0 && PTRIN(args->fromlen) != NULL)
 		error = copyout(&msg.msg_namelen, PTRIN(args->fromlen),
@@ -1561,180 +1516,27 @@ linux_sendmmsg(struct thread *td, struct linux_sendmmsg_args *args)
 }
 
 static int
-recvmsg_scm_rights(struct thread *td, l_uint flags, socklen_t *datalen,
-    void **data, void **udata)
-{
-	int i, fd, fds, *fdp;
-
-	if (flags & LINUX_MSG_CMSG_CLOEXEC) {
-		fds = *datalen / sizeof(int);
-		fdp = *data;
-		for (i = 0; i < fds; i++) {
-			fd = *fdp++;
-			(void)kern_fcntl(td, fd, F_SETFD, FD_CLOEXEC);
-		}
-	}
-	return (0);
-}
-
-
-static int
-recvmsg_scm_creds(socklen_t *datalen, void **data, void **udata)
-{
-	struct cmsgcred *cmcred;
-	struct l_ucred lu;
-
-	cmcred = *data;
-	lu.pid = cmcred->cmcred_pid;
-	lu.uid = cmcred->cmcred_uid;
-	lu.gid = cmcred->cmcred_gid;
-	memmove(*data, &lu, sizeof(lu));
-	*datalen = sizeof(lu);
-	return (0);
-}
-_Static_assert(sizeof(struct cmsgcred) >= sizeof(struct l_ucred),
-    "scm_creds sizeof l_ucred");
-
-static int
-recvmsg_scm_creds2(socklen_t *datalen, void **data, void **udata)
-{
-	struct sockcred2 *scred;
-	struct l_ucred lu;
-
-	scred = *data;
-	lu.pid = scred->sc_pid;
-	lu.uid = scred->sc_uid;
-	lu.gid = scred->sc_gid;
-	memmove(*data, &lu, sizeof(lu));
-	*datalen = sizeof(lu);
-	return (0);
-}
-_Static_assert(sizeof(struct sockcred2) >= sizeof(struct l_ucred),
-    "scm_creds2 sizeof l_ucred");
-
-#if defined(__i386__) || (defined(__amd64__) && defined(COMPAT_LINUX32))
-static int
-recvmsg_scm_timestamp(l_int msg_type, socklen_t *datalen, void **data,
-    void **udata)
-{
-	l_sock_timeval ltv64;
-	l_timeval ltv;
-	struct timeval *tv;
-	socklen_t len;
-	void *buf;
-
-	if (*datalen != sizeof(struct timeval))
-		return (EMSGSIZE);
-
-	tv = *data;
-#if defined(COMPAT_LINUX32)
-	if (msg_type == LINUX_SCM_TIMESTAMPO &&
-	    (tv->tv_sec > INT_MAX || tv->tv_sec < INT_MIN))
-		return (EOVERFLOW);
-#endif
-	if (msg_type == LINUX_SCM_TIMESTAMPN)
-		len = sizeof(ltv64);
-	else
-		len = sizeof(ltv);
-
-	buf = malloc(len, M_LINUX, M_WAITOK);
-	if (msg_type == LINUX_SCM_TIMESTAMPN) {
-		ltv64.tv_sec = tv->tv_sec;
-		ltv64.tv_usec = tv->tv_usec;
-		memmove(buf, &ltv64, len);
-	} else {
-		ltv.tv_sec = tv->tv_sec;
-		ltv.tv_usec = tv->tv_usec;
-		memmove(buf, &ltv, len);
-	}
-	*data = *udata = buf;
-	*datalen = len;
-	return (0);
-}
-#else
-_Static_assert(sizeof(struct timeval) == sizeof(l_timeval),
-    "scm_timestamp sizeof l_timeval");
-#endif /* __i386__ || (__amd64__ && COMPAT_LINUX32) */
-
-#if defined(__i386__) || (defined(__amd64__) && defined(COMPAT_LINUX32))
-static int
-recvmsg_scm_timestampns(l_int msg_type, socklen_t *datalen, void **data,
-    void **udata)
-{
-	struct l_timespec64 ts64;
-	struct l_timespec ts32;
-	struct timespec ts;
-	socklen_t len;
-	void *buf;
-
-	if (msg_type == LINUX_SCM_TIMESTAMPNSO)
-		len = sizeof(ts32);
-	else
-		len = sizeof(ts64);
-
-	buf = malloc(len, M_LINUX, M_WAITOK);
-	bintime2timespec(*data, &ts);
-	if (msg_type == LINUX_SCM_TIMESTAMPNSO) {
-		ts32.tv_sec = ts.tv_sec;
-		ts32.tv_nsec = ts.tv_nsec;
-		memmove(buf, &ts32, len);
-	} else {
-		ts64.tv_sec = ts.tv_sec;
-		ts64.tv_nsec = ts.tv_nsec;
-		memmove(buf, &ts64, len);
-	}
-	*data = *udata = buf;
-	*datalen = len;
-	return (0);
-}
-#else
-static int
-recvmsg_scm_timestampns(l_int msg_type, socklen_t *datalen, void **data,
-    void **udata)
-{
-	struct timespec ts;
-
-	bintime2timespec(*data, &ts);
-	memmove(*data, &ts, sizeof(struct timespec));
-	*datalen = sizeof(struct timespec);
-	return (0);
-}
-_Static_assert(sizeof(struct bintime) >= sizeof(struct timespec),
-    "scm_timestampns sizeof timespec");
-#endif /* __i386__ || (__amd64__ && COMPAT_LINUX32) */
-
-static int
-recvmsg_scm_ip_origdstaddr(socklen_t *datalen, void **data, void **udata)
-{
-	struct l_sockaddr *lsa;
-	int error;
-
-	error = bsd_to_linux_sockaddr(*data, &lsa, *datalen);
-	if (error == 0) {
-		*data = *udata = lsa;
-		*datalen = sizeof(*lsa);
-	}
-	return (error);
-}
-
-static int
 linux_recvmsg_common(struct thread *td, l_int s, struct l_msghdr *msghdr,
     l_uint flags, struct msghdr *msg)
 {
-	struct proc *p = td->td_proc;
 	struct cmsghdr *cm;
-	struct l_cmsghdr *lcm = NULL;
+	struct cmsgcred *cmcred;
+	struct sockcred2 *scred;
+	struct l_cmsghdr *linux_cmsg = NULL;
+	struct l_ucred linux_ucred;
 	socklen_t datalen, maxlen, outlen;
-	struct l_msghdr l_msghdr;
+	struct l_msghdr linux_msghdr;
 	struct iovec *iov, *uiov;
-	struct mbuf *m, *control = NULL;
+	struct mbuf *control = NULL;
 	struct mbuf **controlp;
+	struct timeval *ftmvl;
 	struct sockaddr *sa;
+	l_timeval ltmvl;
 	caddr_t outbuf;
-	void *data, *udata;
-	int error;
+	void *data;
+	int error, i, fd, fds, *fdp;
 
-	error = copyin(msghdr, &l_msghdr, sizeof(l_msghdr));
+	error = copyin(msghdr, &linux_msghdr, sizeof(linux_msghdr));
 	if (error != 0)
 		return (error);
 
@@ -1742,9 +1544,9 @@ linux_recvmsg_common(struct thread *td, l_int s, struct l_msghdr *msghdr,
 	 * Pass user-supplied recvmsg() flags in msg_flags field,
 	 * following sys_recvmsg() convention.
 	*/
-	l_msghdr.msg_flags = flags;
+	linux_msghdr.msg_flags = flags;
 
-	error = linux_to_bsd_msghdr(msg, &l_msghdr);
+	error = linux_to_bsd_msghdr(msg, &linux_msghdr);
 	if (error != 0)
 		return (error);
 
@@ -1778,115 +1580,132 @@ linux_recvmsg_common(struct thread *td, l_int s, struct l_msghdr *msghdr,
 	 * Note that kern_recvit() updates msg->msg_namelen.
 	 */
 	if (msg->msg_name != NULL && msg->msg_namelen > 0) {
-		msg->msg_name = PTRIN(l_msghdr.msg_name);
-		error = linux_copyout_sockaddr(sa, msg->msg_name,
-		    msg->msg_namelen);
+		msg->msg_name = PTRIN(linux_msghdr.msg_name);
+		error = linux_copyout_sockaddr(sa,
+		    PTRIN(msg->msg_name), msg->msg_namelen);
 		if (error != 0)
 			goto bad;
 	}
 
-	error = bsd_to_linux_msghdr(msg, &l_msghdr);
+	error = bsd_to_linux_msghdr(msg, &linux_msghdr);
 	if (error != 0)
 		goto bad;
 
-	maxlen = l_msghdr.msg_controllen;
-	l_msghdr.msg_controllen = 0;
-	if (control == NULL)
-		goto out;
+	maxlen = linux_msghdr.msg_controllen;
+	linux_msghdr.msg_controllen = 0;
+	if (control) {
+		linux_cmsg = malloc(L_CMSG_HDRSZ, M_LINUX, M_WAITOK | M_ZERO);
 
-	lcm = malloc(L_CMSG_HDRSZ, M_LINUX, M_WAITOK | M_ZERO);
-	msg->msg_control = mtod(control, struct cmsghdr *);
-	msg->msg_controllen = control->m_len;
-	outbuf = PTRIN(l_msghdr.msg_control);
-	outlen = 0;
-	for (m = control; m != NULL; m = m->m_next) {
-		cm = mtod(m, struct cmsghdr *);
-		lcm->cmsg_type = bsd_to_linux_cmsg_type(p, cm->cmsg_type,
-		    cm->cmsg_level);
-		lcm->cmsg_level = bsd_to_linux_sockopt_level(cm->cmsg_level);
+		msg->msg_control = mtod(control, struct cmsghdr *);
+		msg->msg_controllen = control->m_len;
 
-		data = CMSG_DATA(cm);
-		datalen = (caddr_t)cm + cm->cmsg_len - (caddr_t)data;
-		udata = NULL;
-		error = 0;
-
-		/* Process non SOL_SOCKET types. */
-		if (cm->cmsg_level == IPPROTO_IP &&
-		    lcm->cmsg_type == LINUX_IP_ORIGDSTADDR) {
-			error = recvmsg_scm_ip_origdstaddr(&datalen, &data, &udata);
-			goto cont;
-		}
-
-		if (lcm->cmsg_type == -1 ||
-		    cm->cmsg_level != SOL_SOCKET) {
-			LINUX_RATELIMIT_MSG_OPT2(
-			    "unsupported recvmsg cmsg level %d type %d",
-			    cm->cmsg_level, cm->cmsg_type);
-			error = EINVAL;
-			goto bad;
-		}
-
-
-		switch (cm->cmsg_type) {
-		case SCM_RIGHTS:
-			error = recvmsg_scm_rights(td, flags,
-			    &datalen, &data, &udata);
-			break;
-		case SCM_CREDS:
-			error = recvmsg_scm_creds(&datalen,
-			    &data, &udata);
-			break;
-		case SCM_CREDS2:
-			error = recvmsg_scm_creds2(&datalen,
-			    &data, &udata);
-			break;
-		case SCM_TIMESTAMP:
-#if defined(__i386__) || (defined(__amd64__) && defined(COMPAT_LINUX32))
-			error = recvmsg_scm_timestamp(lcm->cmsg_type,
-			    &datalen, &data, &udata);
-#endif
-			break;
-		case SCM_BINTIME:
-			error = recvmsg_scm_timestampns(lcm->cmsg_type,
-			    &datalen, &data, &udata);
-			break;
-		}
-
-cont:
-		if (error != 0)
-			goto bad;
-
-		if (outlen + LINUX_CMSG_LEN(datalen) > maxlen) {
-			if (outlen == 0) {
-				error = EMSGSIZE;
-				goto err;
-			} else {
-				l_msghdr.msg_flags |= LINUX_MSG_CTRUNC;
-				m_dispose_extcontrolm(control);
-				free(udata, M_LINUX);
-				goto out;
+		cm = CMSG_FIRSTHDR(msg);
+		outbuf = PTRIN(linux_msghdr.msg_control);
+		outlen = 0;
+		while (cm != NULL) {
+			linux_cmsg->cmsg_type =
+			    bsd_to_linux_cmsg_type(cm->cmsg_type);
+			linux_cmsg->cmsg_level =
+			    bsd_to_linux_sockopt_level(cm->cmsg_level);
+			if (linux_cmsg->cmsg_type == -1 ||
+			    cm->cmsg_level != SOL_SOCKET) {
+				linux_msg(curthread,
+				    "unsupported recvmsg cmsg level %d type %d",
+				    cm->cmsg_level, cm->cmsg_type);
+				error = EINVAL;
+				goto bad;
 			}
-		}
 
-		lcm->cmsg_len = LINUX_CMSG_LEN(datalen);
-		error = copyout(lcm, outbuf, L_CMSG_HDRSZ);
-		if (error == 0) {
+			data = CMSG_DATA(cm);
+			datalen = (caddr_t)cm + cm->cmsg_len - (caddr_t)data;
+
+			switch (cm->cmsg_type) {
+			case SCM_RIGHTS:
+				if (flags & LINUX_MSG_CMSG_CLOEXEC) {
+					fds = datalen / sizeof(int);
+					fdp = data;
+					for (i = 0; i < fds; i++) {
+						fd = *fdp++;
+						(void)kern_fcntl(td, fd,
+						    F_SETFD, FD_CLOEXEC);
+					}
+				}
+				break;
+
+			case SCM_CREDS:
+				/*
+				 * Currently LOCAL_CREDS is never in
+				 * effect for Linux so no need to worry
+				 * about sockcred
+				 */
+				if (datalen != sizeof(*cmcred)) {
+					error = EMSGSIZE;
+					goto bad;
+				}
+				cmcred = (struct cmsgcred *)data;
+				bzero(&linux_ucred, sizeof(linux_ucred));
+				linux_ucred.pid = cmcred->cmcred_pid;
+				linux_ucred.uid = cmcred->cmcred_uid;
+				linux_ucred.gid = cmcred->cmcred_gid;
+				data = &linux_ucred;
+				datalen = sizeof(linux_ucred);
+				break;
+
+			case SCM_CREDS2:
+				scred = data;
+				bzero(&linux_ucred, sizeof(linux_ucred));
+				linux_ucred.pid = scred->sc_pid;
+				linux_ucred.uid = scred->sc_uid;
+				linux_ucred.gid = scred->sc_gid;
+				data = &linux_ucred;
+				datalen = sizeof(linux_ucred);
+				break;
+
+			case SCM_TIMESTAMP:
+				if (datalen != sizeof(struct timeval)) {
+					error = EMSGSIZE;
+					goto bad;
+				}
+				ftmvl = (struct timeval *)data;
+				ltmvl.tv_sec = ftmvl->tv_sec;
+				ltmvl.tv_usec = ftmvl->tv_usec;
+				data = &ltmvl;
+				datalen = sizeof(ltmvl);
+				break;
+			}
+
+			if (outlen + LINUX_CMSG_LEN(datalen) > maxlen) {
+				if (outlen == 0) {
+					error = EMSGSIZE;
+					goto bad;
+				} else {
+					linux_msghdr.msg_flags |= LINUX_MSG_CTRUNC;
+					m_dispose_extcontrolm(control);
+					goto out;
+				}
+			}
+
+			linux_cmsg->cmsg_len = LINUX_CMSG_LEN(datalen);
+
+			error = copyout(linux_cmsg, outbuf, L_CMSG_HDRSZ);
+			if (error != 0)
+				goto bad;
 			outbuf += L_CMSG_HDRSZ;
+
 			error = copyout(data, outbuf, datalen);
-			if (error == 0) {
-				outbuf += LINUX_CMSG_ALIGN(datalen);
-				outlen += LINUX_CMSG_LEN(datalen);
-			}
+			if (error != 0)
+				goto bad;
+
+			outbuf += LINUX_CMSG_ALIGN(datalen);
+			outlen += LINUX_CMSG_LEN(datalen);
+
+			cm = CMSG_NXTHDR(msg, cm);
 		}
-err:
-		free(udata, M_LINUX);
-		if (error != 0)
-			goto bad;
+		linux_msghdr.msg_controllen = outlen;
 	}
-	l_msghdr.msg_controllen = outlen;
 
 out:
-	error = copyout(&l_msghdr, msghdr, sizeof(l_msghdr));
+	error = copyout(&linux_msghdr, msghdr, sizeof(linux_msghdr));
 
 bad:
 	if (control != NULL) {
@@ -1895,7 +1714,7 @@ bad:
 		m_freem(control);
 	}
 	free(iov, M_IOV);
-	free(lcm, M_LINUX);
+	free(linux_cmsg, M_LINUX);
 	free(sa, M_SONAME);
 
 	return (error);
@@ -1905,36 +1724,37 @@ int
 linux_recvmsg(struct thread *td, struct linux_recvmsg_args *args)
 {
 	struct msghdr bsd_msg;
-	struct file *fp;
-	int error;
 
-	error = getsock_cap(td, args->s, &cap_recv_rights,
-	    &fp, NULL, NULL);
-	if (error != 0)
-		return (error);
-	fdrop(fp, td);
 	return (linux_recvmsg_common(td, args->s, PTRIN(args->msg),
 	    args->flags, &bsd_msg));
 }
 
-static int
-linux_recvmmsg_common(struct thread *td, l_int s, struct l_mmsghdr *msg,
-    l_uint vlen, l_uint flags, struct timespec *tts)
+int
+linux_recvmmsg(struct thread *td, struct linux_recvmmsg_args *args)
 {
+	struct l_mmsghdr *msg;
 	struct msghdr bsd_msg;
-	struct timespec ts;
-	struct file *fp;
+	struct l_timespec lts;
+	struct timespec ts, tts;
 	l_uint retval;
 	int error, datagrams;
 
-	error = getsock_cap(td, s, &cap_recv_rights,
-	    &fp, NULL, NULL);
-	if (error != 0)
-		return (error);
+	if (args->timeout) {
+		error = copyin(args->timeout, &lts, sizeof(struct l_timespec));
+		if (error != 0)
+			return (error);
+		error = linux_to_native_timespec(&ts, &lts);
+		if (error != 0)
+			return (error);
+		getnanotime(&tts);
+		timespecadd(&tts, &ts, &tts);
+	}
+
+	msg = PTRIN(args->msg);
 	datagrams = 0;
-	while (datagrams < vlen) {
-		error = linux_recvmsg_common(td, s, &msg->msg_hdr,
-		    flags & ~LINUX_MSG_WAITFORONE, &bsd_msg);
+	while (datagrams < args->vlen) {
+		error = linux_recvmsg_common(td, args->s, &msg->msg_hdr,
+		    args->flags & ~LINUX_MSG_WAITFORONE, &bsd_msg);
 		if (error != 0)
 			break;
 
@@ -1948,15 +1768,15 @@ linux_recvmmsg_common(struct thread *td, l_int s, struct l_mmsghdr *msg,
 		/*
 		 * MSG_WAITFORONE turns on MSG_DONTWAIT after one packet.
 		 */
-		if (flags & LINUX_MSG_WAITFORONE)
-			flags |= LINUX_MSG_DONTWAIT;
+		if (args->flags & LINUX_MSG_WAITFORONE)
+			args->flags |= LINUX_MSG_DONTWAIT;
 
 		/*
 		 * See BUGS section of recvmmsg(2).
 		 */
-		if (tts) {
+		if (args->timeout) {
 			getnanotime(&ts);
-			timespecsub(&ts, tts, &ts);
+			timespecsub(&ts, &tts, &ts);
 			if (!timespecisset(&ts) || ts.tv_sec > 0)
 				break;
 		}
@@ -1966,51 +1786,8 @@ linux_recvmmsg_common(struct thread *td, l_int s, struct l_mmsghdr *msg,
 	}
 	if (error == 0)
 		td->td_retval[0] = datagrams;
-	fdrop(fp, td);
 	return (error);
 }
-
-int
-linux_recvmmsg(struct thread *td, struct linux_recvmmsg_args *args)
-{
-	struct timespec ts, tts, *ptts;
-	int error;
-
-	if (args->timeout) {
-		error = linux_get_timespec(&ts, args->timeout);
-		if (error != 0)
-			return (error);
-		getnanotime(&tts);
-		timespecadd(&tts, &ts, &tts);
-		ptts = &tts;
-	}
-		else ptts = NULL;
-
-	return (linux_recvmmsg_common(td, args->s, PTRIN(args->msg),
-	    args->vlen, args->flags, ptts));
-}
-
-#if defined(__i386__) || (defined(__amd64__) && defined(COMPAT_LINUX32))
-int
-linux_recvmmsg_time64(struct thread *td, struct linux_recvmmsg_time64_args *args)
-{
-	struct timespec ts, tts, *ptts;
-	int error;
-
-	if (args->timeout) {
-		error = linux_get_timespec64(&ts, args->timeout);
-		if (error != 0)
-			return (error);
-		getnanotime(&tts);
-		timespecadd(&tts, &ts, &tts);
-		ptts = &tts;
-	}
-		else ptts = NULL;
-
-	return (linux_recvmmsg_common(td, args->s, PTRIN(args->msg),
-	    args->vlen, args->flags, ptts));
-}
-#endif
 
 int
 linux_shutdown(struct thread *td, struct linux_shutdown_args *args)
@@ -2022,13 +1799,11 @@ linux_shutdown(struct thread *td, struct linux_shutdown_args *args)
 int
 linux_setsockopt(struct thread *td, struct linux_setsockopt_args *args)
 {
-	struct proc *p = td->td_proc;
-	struct linux_pemuldata *pem;
 	l_timeval linux_tv;
 	struct sockaddr *sa;
 	struct timeval tv;
 	socklen_t len;
-	int error, level, name, val;
+	int error, level, name;
 
 	level = linux_to_bsd_sockopt_level(args->level);
 	switch (level) {
@@ -2050,26 +1825,6 @@ linux_setsockopt(struct thread *td, struct linux_setsockopt_args *args)
 			return (kern_setsockopt(td, args->s, level,
 			    name, &tv, UIO_SYSSPACE, sizeof(tv)));
 			/* NOTREACHED */
-		case SO_TIMESTAMP:
-			/* overwrite SO_BINTIME */
-			val = 0;
-			error = kern_setsockopt(td, args->s, level,
-			    SO_BINTIME, &val, UIO_SYSSPACE, sizeof(val));
-			if (error != 0)
-				return (error);
-			pem = pem_find(p);
-			pem->so_timestamp = args->optname;
-			break;
-		case SO_BINTIME:
-			/* overwrite SO_TIMESTAMP */
-			val = 0;
-			error = kern_setsockopt(td, args->s, level,
-			    SO_TIMESTAMP, &val, UIO_SYSSPACE, sizeof(val));
-			if (error != 0)
-				return (error);
-			pem = pem_find(p);
-			pem->so_timestampns = args->optname;
-			break;
 		default:
 			break;
 		}
@@ -2117,18 +1872,6 @@ linux_setsockopt(struct thread *td, struct linux_setsockopt_args *args)
 		    name, PTRIN(args->optval), UIO_USERSPACE, args->optlen);
 	}
 
-	return (error);
-}
-
-static int
-linux_sockopt_copyout(struct thread *td, void *val, socklen_t len,
-    struct linux_getsockopt_args *args)
-{
-	int error;
-
-	error = copyout(val, PTRIN(args->optval), len);
-	if (error == 0)
-		error = copyout(&len, PTRIN(args->optlen), sizeof(len));
 	return (error);
 }
 
@@ -2184,25 +1927,11 @@ linux_getsockopt_so_peersec(struct thread *td,
 		return (error);
 	}
 
-	return (linux_sockopt_copyout(td, SECURITY_CONTEXT_STRING,
-	    len, args));
-}
-
-static int
-linux_getsockopt_so_linger(struct thread *td,
-    struct linux_getsockopt_args *args)
-{
-	struct linger ling;
-	socklen_t len;
-	int error;
-
-	len = sizeof(ling);
-	error = kern_getsockopt(td, args->s, SOL_SOCKET,
-	    SO_LINGER, &ling, UIO_SYSSPACE, &len);
-	if (error != 0)
-		return (error);
-	ling.l_onoff = ((ling.l_onoff & SO_LINGER) != 0);
-	return (linux_sockopt_copyout(td, &ling, len, args));
+	error = copyout(SECURITY_CONTEXT_STRING,
+	    PTRIN(args->optval), sizeof(SECURITY_CONTEXT_STRING));
+	if (error == 0)
+		error = copyout(&len, PTRIN(args->optlen), sizeof(len));
+	return (error);
 }
 
 int
@@ -2243,8 +1972,8 @@ linux_getsockopt(struct thread *td, struct linux_getsockopt_args *args)
 				return (error);
 			linux_tv.tv_sec = tv.tv_sec;
 			linux_tv.tv_usec = tv.tv_usec;
-			return (linux_sockopt_copyout(td, &linux_tv,
-			    sizeof(linux_tv), args));
+			return (copyout(&linux_tv, PTRIN(args->optval),
+			    sizeof(linux_tv)));
 			/* NOTREACHED */
 		case LOCAL_PEERCRED:
 			if (args->optlen < sizeof(lxu))
@@ -2262,8 +1991,7 @@ linux_getsockopt(struct thread *td, struct linux_getsockopt_args *args)
 			lxu.pid = xu.cr_pid;
 			lxu.uid = xu.cr_uid;
 			lxu.gid = xu.cr_gid;
-			return (linux_sockopt_copyout(td, &lxu,
-			    sizeof(lxu), args));
+			return (copyout(&lxu, PTRIN(args->optval), sizeof(lxu)));
 			/* NOTREACHED */
 		case SO_ERROR:
 			len = sizeof(newval);
@@ -2272,23 +2000,7 @@ linux_getsockopt(struct thread *td, struct linux_getsockopt_args *args)
 			if (error != 0)
 				return (error);
 			newval = -bsd_to_linux_errno(newval);
-			return (linux_sockopt_copyout(td, &newval,
-			    len, args));
-			/* NOTREACHED */
-		case SO_DOMAIN:
-			len = sizeof(newval);
-			error = kern_getsockopt(td, args->s, level,
-			    name, &newval, UIO_SYSSPACE, &len);
-			if (error != 0)
-				return (error);
-			newval = bsd_to_linux_domain(newval);
-			if (newval == -1)
-				return (ENOPROTOOPT);
-			return (linux_sockopt_copyout(td, &newval,
-			    len, args));
-			/* NOTREACHED */
-		case SO_LINGER:
-			return (linux_getsockopt_so_linger(td, args));
+			return (copyout(&newval, PTRIN(args->optval), len));
 			/* NOTREACHED */
 		default:
 			break;
@@ -2348,6 +2060,143 @@ out:
 	return (error);
 }
 
+
+/*
+ * Based on sendfile_getsock from kern_sendfile.c
+ * Determines whether an fd is a stream socket that can be used
+ * with FreeBSD sendfile.
+ */
+static bool
+_is_stream_socket(struct thread *td, l_int fd)
+{
+	int error;
+	struct file *sock_fp = NULL;
+	struct socket *so = NULL;
+
+	/*
+	 * The socket must be a stream socket and connected.
+	 */
+	error = getsock_cap(td, fd, &cap_send_rights,
+	    &sock_fp, NULL, NULL);
+	if (error != 0)
+		return false;
+	so = sock_fp->f_data;
+	if (so->so_type != SOCK_STREAM)
+		return false;
+	/*
+	 * SCTP one-to-one style sockets currently don't work with
+	 * sendfile().
+	 */
+	if (so->so_proto->pr_protocol == IPPROTO_SCTP)
+		return false;
+	if (SOLISTENING(so))
+		return false;
+
+	return true;
+}
+
+#define TMPBUF_SIZE 8192
+
+static int
+_sendfile_fallback(struct thread *td, struct file *fp,
+	struct file *outfp, l_loff_t current_offset,
+	l_size_t count, off_t *bytes_read)
+{
+	int error;
+	struct uio auio;
+	struct iovec aiov;
+	void *tmpbuf;
+	off_t out_offset;
+	l_size_t bytes_sent;
+	l_size_t n_read;
+
+	error = (outfp->f_ops->fo_flags & DFLAG_SEEKABLE) != 0 ?
+		fo_seek(outfp, 0, SEEK_CUR, td) : 0;
+
+	if (error != 0)
+		return (error);
+
+	out_offset = td->td_uretoff.tdu_off;
+
+	bytes_sent = 0;
+	tmpbuf = malloc(TMPBUF_SIZE, M_TEMP, M_WAITOK);
+
+	if(!tmpbuf) {
+		error = ENOMEM;
+		return (error);
+	}
+
+	while(bytes_sent < count) {
+
+		off_t to_send = MIN(count - bytes_sent, TMPBUF_SIZE);
+
+		/*
+		 * Read
+		 */
+
+		aiov.iov_base = tmpbuf;
+		aiov.iov_len = TMPBUF_SIZE;
+
+		auio.uio_iov = &aiov;
+		auio.uio_iovcnt = 1;
+		auio.uio_segflg = UIO_SYSSPACE;
+		auio.uio_td = td;
+
+		auio.uio_rw = UIO_READ;
+		auio.uio_offset = current_offset + bytes_sent;
+		auio.uio_resid = to_send;
+
+		error = fo_read(fp, &auio, fp->f_cred, FOF_OFFSET, td);
+		if (error != 0) {
+			goto cleanup;
+		}
+
+		n_read = to_send - auio.uio_resid;
+
+		if(n_read == 0)
+			break; /* eof */
+
+		/*
+		 * Write
+		 */
+
+		aiov.iov_base = tmpbuf;
+		aiov.iov_len = TMPBUF_SIZE;
+
+		auio.uio_iov = &aiov;
+		auio.uio_iovcnt = 1;
+		auio.uio_segflg = UIO_SYSSPACE;
+		auio.uio_td = td;
+
+		auio.uio_rw = UIO_WRITE;
+
+		auio.uio_offset = ((outfp->f_ops->fo_flags & DFLAG_SEEKABLE) != 0) ?
+			out_offset + bytes_sent :
+			0;
+
+		auio.uio_resid = n_read;
+
+		error = fo_write(outfp, &auio, outfp->f_cred, FOF_OFFSET, td);
+		if (error != 0) {
+			goto cleanup;
+		}
+
+		bytes_sent += n_read;
+	}
+
+	if((outfp->f_ops->fo_flags & DFLAG_SEEKABLE) != 0) {
+		error = fo_seek(outfp, out_offset + bytes_sent, SEEK_SET, td);
+		if (error != 0) {
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	*bytes_read = bytes_sent;
+	free(tmpbuf, M_TEMP);
+	return (error);
+}
+
 static int
 linux_sendfile_common(struct thread *td, l_int out, l_int in,
     l_loff_t *offset, l_size_t count)
@@ -2355,12 +2204,17 @@ linux_sendfile_common(struct thread *td, l_int out, l_int in,
 	off_t bytes_read;
 	int error;
 	l_loff_t current_offset;
-	struct file *fp;
+	struct file *fp, *outfp;
+	bool use_sendfile;
 
 	AUDIT_ARG_FD(in);
 	error = fget_read(td, in, &cap_pread_rights, &fp);
 	if (error != 0)
 		return (error);
+
+	use_sendfile = _is_stream_socket(td, out) &&
+		((fp->f_type == DTYPE_VNODE && fp->f_vnode->v_type == VREG) ||
+		 fp->f_type == DTYPE_SHM);
 
 	if (offset != NULL) {
 		current_offset = *offset;
@@ -2380,10 +2234,21 @@ linux_sendfile_common(struct thread *td, l_int out, l_int in,
 		goto drop;
 	}
 
-	error = fo_sendfile(fp, out, NULL, NULL, current_offset, count,
-	    &bytes_read, 0, td);
-	if (error != 0)
+	if(use_sendfile) {
+		error = fo_sendfile(fp, out, NULL, NULL, current_offset, count,
+				&bytes_read, 0, td);
+	} else {
+		error = fget_write(td, out, &cap_pwrite_rights, &outfp);
+		if (error != 0)
+			return (error);
+		error = _sendfile_fallback(td, fp, outfp, current_offset, count, &bytes_read);
+		fdrop(outfp, td);
+	}
+
+	if (error != 0) {
 		goto drop;
+	}
+
 	current_offset += bytes_read;
 
 	if (offset != NULL) {
@@ -2411,7 +2276,8 @@ linux_sendfile(struct thread *td, struct linux_sendfile_args *arg)
 	 *   mean send the whole file.)  In linux_sendfile given fds are still
 	 *   checked for validity when the count is 0.
 	 * - Linux can send to any fd whereas FreeBSD only supports sockets.
-	 *   The same restriction follows for linux_sendfile.
+	 *   We therefore use FreeBSD sendfile where possible for performance,
+	 *   but fall back on a manual copy (_sendfile_fallback)
 	 * - Linux doesn't have an equivalent for FreeBSD's flags and sf_hdtr.
 	 * - Linux takes an offset pointer and updates it to the read location.
 	 *   FreeBSD takes in an offset and a 'bytes read' parameter which is


### PR DESCRIPTION
In Linux < 2.6.33, sendfile could only be used to send from a file to a socket. This is the behaviour implemented by the FreeBSD Linuxulator. However, since 2.6.33, sendfile can send from any FD to any other FD, which is not implemented by FreeBSD sendfile or by the Linuxulator.